### PR TITLE
concurrent caching data

### DIFF
--- a/app/src/main/java/com/bakapiano/maimai/updater/crawler/WechatCrawler.java
+++ b/app/src/main/java/com/bakapiano/maimai/updater/crawler/WechatCrawler.java
@@ -2,6 +2,7 @@ package com.bakapiano.maimai.updater.crawler;
 
 import static com.bakapiano.maimai.updater.crawler.CrawlerCaller.writeLog;
 
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
@@ -9,9 +10,15 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,61 +48,149 @@ public class WechatCrawler {
     private static final String TAG = "Crawler";
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     private static final MediaType TEXT = MediaType.parse("text/plain");
-
-    private static OkHttpClient client = null;
     private static final SimpleCookieJar jar = new SimpleCookieJar();
+    private static final Map<Integer, String> diffMap = new HashMap<>();
+    private static OkHttpClient client = null;
 
     protected WechatCrawler() {
+        diffMap.put(0, "Basic");
+        diffMap.put(1, "Advance");
+        diffMap.put(2, "Expert");
+        diffMap.put(3, "Master");
+        diffMap.put(4, "Re:Master");
         buildHttpClient(false);
     }
 
+    private static void uploadData(int i, String data) {
+        Request request = new Request.Builder().url("https://www.diving-fish.com/api/pageparser/page").addHeader("content-type", "text/plain").post(RequestBody.create(data, TEXT)).build();
+        Callback callback = new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                try {
+                    throw e;
+                } catch (IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException {
+                assert response.body() != null;
+                String result = response.body().string();
+                Log.d(TAG, result);
+                writeLog(diffMap.get(i) + " 难度数据上传完成：" + result);
+//                writeLog("diff = " + i + " " + result);
+            }
+
+        };
+        client.newCall(request).enqueue(callback);
+    }
+
+    private static void fetchAndUploadData(String username, String password, Set<Integer> difficulties) throws IOException {
+        fetchAndUploadData(username, password, difficulties, new ArrayList<>());
+    }
+
+    private static void fetchAndUploadData(String username, String password, Set<Integer> difficulties, List<CompletableFuture<Object>> tasks) throws IOException {
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Iterator<Integer> iterator = difficulties.iterator();
+            if (iterator.hasNext()) {
+                Integer diff = iterator.next();
+                Request request = new Request.Builder().url("https://maimai.wahlap.com/maimai-mobile/record/musicGenre/search/?genre=99&diff=" + diff).build();
+
+                writeLog("开始获取 " + diffMap.get(diff) + " 难度的数据");
+
+                client.newCall(request).enqueue(new Callback() {
+                    @Override
+                    public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    @Override
+                    public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException {
+                        tasks.add(CompletableFuture.supplyAsync(() -> {
+                            Log.d(TAG, response.request().url() + " " + response.code());
+                            String data;
+                            try {
+                                data = Objects.requireNonNull(response.body()).string();
+                                Matcher matcher = Pattern.compile("<html.*>([\\s\\S]*)</html>").matcher(data);
+                                if (matcher.find()) data = Objects.requireNonNull(matcher.group(1));
+                                data = Pattern.compile("\\s+").matcher(data).replaceAll(" ");
+
+//                                writeLog("diff = " + diff + " was cached");
+                                writeLog(diffMap.get(diff) + " 难度的数据已获取，正在上传至水鱼查分器");
+
+                                // Upload data to maimai-prober
+                                uploadData(diff, "<login><u>" + username + "</u><p>" + password + "</p></login>" + data);
+                            } catch (IOException e) {
+                                Log.d(TAG, "fetchAndUploadData: " + diff);
+                                throw new RuntimeException(e);
+                            }
+
+                            return diff;
+                        }));
+                        difficulties.remove(diff);
+                        if (!difficulties.isEmpty()) {
+                            fetchAndUploadData(username, password, difficulties, tasks);
+                        } else {
+                            for (CompletableFuture<Object> task : tasks) {
+                                task.join();
+                            }
+                            writeLog("maimai 数据缓存完成，请等待数据上传至水鱼查分器");
+                        }
+                    }
+                });
+            }
+
+        } else {
+
+            for (int diff : difficulties) {
+                // Fetch data
+                Request request = new Request.Builder().url("https://maimai.wahlap.com/maimai-mobile/record/musicGenre/search/?genre=99&diff=" + diff).build();
+
+                Log.d("Cookie", "diff = " + diff + " start");
+
+                Call call = client.newCall(request);
+                try (Response response = call.execute()) {
+                    Log.d(TAG, response.request().url() + " " + response.code());
+                    @NonNull String data = Objects.requireNonNull(response.body()).string();
+
+                    Matcher matcher = Pattern.compile("<html.*>([\\s\\S]*)</html>").matcher(data);
+                    if (matcher.find()) data = Objects.requireNonNull(matcher.group(1));
+                    data = Pattern.compile("\\s+").matcher(data).replaceAll(" ");
+
+                    writeLog("diff = " + diff + " was cached");
+
+                    // Upload data to maimai-prober
+                    uploadData(diff, "<login><u>" + username + "</u><p>" + password + "</p></login>" + data);
+                }
+
+            }
+        }
+    }
+
     public boolean verifyProberAccount(String username, String password) throws IOException {
-        String data = String.format(
-                "{\"username\" : \"%s\", \"password\" : \"%s\"}",
-                username,
-                password);
+        String data = String.format("{\"username\" : \"%s\", \"password\" : \"%s\"}", username, password);
         RequestBody body = RequestBody.create(JSON, data);
 
-        Request request = new Request.Builder()
-                .addHeader("Host", "www.diving-fish.com")
-                .addHeader("Origin", "https://www.diving-fish.com")
-                .addHeader("Referer", "https://www.diving-fish.com/maimaidx/prober/")
-                .url("https://www.diving-fish.com/api/maimaidxprober/login")
-                .post(body)
-                .build();
+        Request request = new Request.Builder().addHeader("Host", "www.diving-fish.com").addHeader("Origin", "https://www.diving-fish.com").addHeader("Referer", "https://www.diving-fish.com/maimaidx/prober/").url("https://www.diving-fish.com/api/maimaidxprober/login").post(body).build();
 
         Call call = client.newCall(request);
         Response response = call.execute();
-        String responseBody = response.body().string().toString();
+        String responseBody = response.body().string();
 
-        Log.d(TAG, "Verify account: " + responseBody + response.toString());
+        Log.d(TAG, "Verify account: " + responseBody + response);
         return !responseBody.contains("errcode");
     }
 
     protected String getWechatAuthUrl() throws IOException {
         this.buildHttpClient(true);
 
-        Request request = new Request.Builder()
-                .addHeader("Host", "tgk-wcaime.wahlap.com")
-                .addHeader("Upgrade-Insecure-Requests", "1")
-                .addHeader("User-Agent", "Mozilla/5.0 (Linux; Android 12; IN2010 Build/RKQ1.211119.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/86.0.4240.99 XWEB/4317 MMWEBSDK/20220903 Mobile Safari/537.36 MMWEBID/363 MicroMessenger/8.0.28.2240(0x28001C57) WeChat/arm64 Weixin NetType/WIFI Language/zh_CN ABI/arm64")
-                .addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/wxpic,image/tpg,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9")
-                .addHeader("X-Requested-With", "com.tencent.mm")
-                .addHeader("Sec-Fetch-Site", "none")
-                .addHeader("Sec-Fetch-Mode", "navigate")
-                .addHeader("Sec-Fetch-User", "?1")
-                .addHeader("Sec-Fetch-Dest", "document")
-                .addHeader("Accept-Encoding", "gzip, deflate")
-                .addHeader("Accept-Language", "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7")
-                .url("https://tgk-wcaime.wahlap.com/wc_auth/oauth/authorize/maimai-dx")
-                .build();
+        Request request = new Request.Builder().addHeader("Host", "tgk-wcaime.wahlap.com").addHeader("Upgrade-Insecure-Requests", "1").addHeader("User-Agent", "Mozilla/5.0 (Linux; Android 12; IN2010 Build/RKQ1.211119.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/86.0.4240.99 XWEB/4317 MMWEBSDK/20220903 Mobile Safari/537.36 MMWEBID/363 MicroMessenger/8.0.28.2240(0x28001C57) WeChat/arm64 Weixin NetType/WIFI Language/zh_CN ABI/arm64").addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/wxpic,image/tpg,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9").addHeader("X-Requested-With", "com.tencent.mm").addHeader("Sec-Fetch-Site", "none").addHeader("Sec-Fetch-Mode", "navigate").addHeader("Sec-Fetch-User", "?1").addHeader("Sec-Fetch-Dest", "document").addHeader("Accept-Encoding", "gzip, deflate").addHeader("Accept-Language", "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7").url("https://tgk-wcaime.wahlap.com/wc_auth/oauth/authorize/maimai-dx").build();
 
         Call call = client.newCall(request);
         Response response = call.execute();
-        String url = response.request()
-                .url()
-                .toString()
-                .replace("redirect_uri=https", "redirect_uri=http");
+        String url = response.request().url().toString().replace("redirect_uri=https", "redirect_uri=http");
 
         Log.d(TAG, "Auth url:" + url);
         return url;
@@ -120,9 +215,11 @@ public class WechatCrawler {
         // Fetch maimai data
         try {
             this.fetchMaimaiData(username, password, difficulties);
-            writeLog("maimai 数据更新完成");
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+                writeLog("maimai 数据更新完成");
+            }
         } catch (Exception error) {
-            writeLog("maimai 数据更新时出线错误:");
+            writeLog("maimai 数据更新时出现错误:");
             writeLog(error);
             return;
         }
@@ -137,21 +234,7 @@ public class WechatCrawler {
         Log.d(TAG, wechatAuthUrl);
         writeLog("登录url:\n" + wechatAuthUrl);
 
-        Request request = new Request.Builder()
-                .addHeader("Host", "tgk-wcaime.wahlap.com")
-                .addHeader("Upgrade-Insecure-Requests", "1")
-                .addHeader("User-Agent", "Mozilla/5.0 (Linux; Android 12; IN2010 Build/RKQ1.211119.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/86.0.4240.99 XWEB/4317 MMWEBSDK/20220903 Mobile Safari/537.36 MMWEBID/363 MicroMessenger/8.0.28.2240(0x28001C57) WeChat/arm64 Weixin NetType/WIFI Language/zh_CN ABI/arm64")
-                .addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/wxpic,image/tpg,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9")
-                .addHeader("X-Requested-With", "com.tencent.mm")
-                .addHeader("Sec-Fetch-Site", "none")
-                .addHeader("Sec-Fetch-Mode", "navigate")
-                .addHeader("Sec-Fetch-User", "?1")
-                .addHeader("Sec-Fetch-Dest", "document")
-                .addHeader("Accept-Encoding", "gzip, deflate")
-                .addHeader("Accept-Language", "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7")
-                .get()
-                .url(wechatAuthUrl)
-                .build();
+        Request request = new Request.Builder().addHeader("Host", "tgk-wcaime.wahlap.com").addHeader("Upgrade-Insecure-Requests", "1").addHeader("User-Agent", "Mozilla/5.0 (Linux; Android 12; IN2010 Build/RKQ1.211119.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/86.0.4240.99 XWEB/4317 MMWEBSDK/20220903 Mobile Safari/537.36 MMWEBID/363 MicroMessenger/8.0.28.2240(0x28001C57) WeChat/arm64 Weixin NetType/WIFI Language/zh_CN ABI/arm64").addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/wxpic,image/tpg,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9").addHeader("X-Requested-With", "com.tencent.mm").addHeader("Sec-Fetch-Site", "none").addHeader("Sec-Fetch-Mode", "navigate").addHeader("Sec-Fetch-User", "?1").addHeader("Sec-Fetch-Dest", "document").addHeader("Accept-Encoding", "gzip, deflate").addHeader("Accept-Language", "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7").get().url(wechatAuthUrl).build();
 
         Call call = client.newCall(request);
         Response response = call.execute();
@@ -173,10 +256,7 @@ public class WechatCrawler {
         // Handle redirect manually
         String location = response.headers().get("Location");
         if (response.code() >= 300 && response.code() < 400 && location != null) {
-            request = new Request.Builder()
-                    .url(location)
-                    .get()
-                    .build();
+            request = new Request.Builder().url(location).get().build();
             call = client.newCall(request);
             call.execute().close();
         }
@@ -185,60 +265,6 @@ public class WechatCrawler {
     private void fetchMaimaiData(String username, String password, Set<Integer> difficulties) throws IOException {
         this.buildHttpClient(false);
         fetchAndUploadData(username, password, difficulties);
-    }
-
-    private static void uploadData(int i, String data) {
-        Request request = new Request.Builder()
-                .url("https://www.diving-fish.com/api/pageparser/page")
-                .addHeader("content-type", "text/plain")
-                .post(RequestBody.create(data, TEXT))
-                .build();
-        Callback callback = new Callback() {
-            @Override
-            public void onFailure(@NotNull Call call, @NotNull IOException e) {
-                try {
-                    throw e;
-                } catch (IOException ex) {
-                    throw new RuntimeException(ex);
-                }
-            }
-
-            @Override
-            public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException {
-                assert response.body() != null;
-                String result = response.body().string();
-                Log.d(TAG, result);
-                writeLog("diff = " + i + " " + result);
-            }
-
-        };
-        client.newCall(request).enqueue(callback);
-    }
-
-    private static void fetchAndUploadData(String username, String password, Set<Integer> difficulties) throws IOException {
-        for (int diff : difficulties) {
-            // Fetch data
-            Request request = new Request.Builder()
-                    .url("https://maimai.wahlap.com/maimai-mobile/record/musicGenre/search/?genre=99&diff=" + diff)
-                    .build();
-
-            Log.d("Cookie", "diff = " + diff + " start");
-
-            Call call = client.newCall(request);
-            try (Response response = call.execute()) {
-                @NonNull String data = Objects.requireNonNull(response.body()).string();
-
-                Log.d(TAG, response.request().url() + " " + response.code());
-                Matcher matcher = Pattern.compile("<html.*>([\\s\\S]*)</html>").matcher(data);
-                if (matcher.find()) data = Objects.requireNonNull(matcher.group(1));
-                data = Pattern.compile("\\s+").matcher(data).replaceAll(" ");
-
-                writeLog("diff = " + diff + " was cached");
-
-                // Upload data to maimai-prober
-                uploadData(diff, "<login><u>" + username + "</u><p>" + password + "</p></login>" + data);
-            }
-        }
     }
 
     private void fetchChunithmData(String username, String password) throws IOException {
@@ -270,10 +296,7 @@ public class WechatCrawler {
         builder.addInterceptor(noCacheInterceptor);
 
         // Fix SSL handle shake error
-        ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.COMPATIBLE_TLS)
-                .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0)
-                .allEnabledCipherSuites()
-                .build();
+        ConnectionSpec spec = new ConnectionSpec.Builder(ConnectionSpec.COMPATIBLE_TLS).tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_1, TlsVersion.TLS_1_0).allEnabledCipherSuites().build();
         // 兼容http接口
         ConnectionSpec spec1 = new ConnectionSpec.Builder(ConnectionSpec.CLEARTEXT).build();
         builder.connectionSpecs(Arrays.asList(spec, spec1));
@@ -285,22 +308,20 @@ public class WechatCrawler {
 
     private void ignoreCertBuilder(OkHttpClient.Builder builder) {
         try {
-            final TrustManager[] trustAllCerts = new TrustManager[]{
-                    new X509TrustManager() {
-                        @Override
-                        public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                        }
+            final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                }
 
-                        @Override
-                        public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                        }
+                @Override
+                public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                }
 
-                        @Override
-                        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                            return new java.security.cert.X509Certificate[]{};
-                        }
-                    }
-            };
+                @Override
+                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                    return new java.security.cert.X509Certificate[]{};
+                }
+            }};
             final SSLContext sslContext = SSLContext.getInstance("SSL");
             sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
             // Create an ssl socket factory with our all-trusting manager

--- a/app/src/main/java/com/bakapiano/maimai/updater/server/HttpRedirectServer.java
+++ b/app/src/main/java/com/bakapiano/maimai/updater/server/HttpRedirectServer.java
@@ -25,6 +25,6 @@ public class HttpRedirectServer extends NanoHTTPD {
         return newFixedLengthResponse(
                 Response.Status.ACCEPTED,
                 MIME_HTML,
-                "<html></html><script>alert('Perfect!');</script>");
+                "<html><body>必要数据已获取,可关闭该窗口并请切回到更新器等待分数上传!</body></html><script>alert('必要数据已获取,请切回到更新器等待分数上传!');</script>");
     }
 }

--- a/app/src/main/java/com/bakapiano/maimai/updater/ui/DataContext.java
+++ b/app/src/main/java/com/bakapiano/maimai/updater/ui/DataContext.java
@@ -9,11 +9,14 @@ public class DataContext {
     public static boolean AutoLaunch = true;
 
     public static String HookHost = "bakapiano.com";
+    public static String WebHost = "https://maimai.bakapiano.com/shortcut?username=bakapiano666&password=114514";
+    public static String ProxyHost = "proxy.bakapiano.com";
+    public static int ProxyPort = 2569;
     public static boolean CompatibleMode = false;
 
-    public static boolean BasicEnabled = true;
+    public static boolean BasicEnabled = false;
 
-    public static boolean AdvancedEnabled = true;
+    public static boolean AdvancedEnabled = false;
 
     public static boolean ExpertEnabled = true;
 

--- a/app/src/main/java/com/bakapiano/maimai/updater/ui/MainActivity.java
+++ b/app/src/main/java/com/bakapiano/maimai/updater/ui/MainActivity.java
@@ -4,6 +4,8 @@ import static com.bakapiano.maimai.updater.Util.copyText;
 import static com.bakapiano.maimai.updater.Util.getDifficulties;
 import static com.bakapiano.maimai.updater.crawler.CrawlerCaller.writeLog;
 
+import static java.lang.Integer.parseInt;
+
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
@@ -11,6 +13,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -28,6 +31,8 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.Switch;
 import android.widget.TextView;
@@ -223,7 +228,7 @@ public class MainActivity extends AppCompatActivity implements
                         if ((Boolean) result) {
 //                            getAuthLink(link -> {
                             if (DataContext.CopyUrl) {
-                                String link = "https://maimai.bakapiano.com/shortcut?username=bakapiano666&password=114514";
+                                String link = DataContext.WebHost;
                                 this.runOnUiThread(() -> copyText(context, link));
                             }
 
@@ -321,6 +326,77 @@ public class MainActivity extends AppCompatActivity implements
                         .setPositiveButton(R.string.btn_ok, null)
                         .show();
                 return true;
+            case R.id.menu_item_proxy:
+                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                builder.setTitle("代理设置");
+
+                LinearLayout layout = new LinearLayout(this);
+                layout.setOrientation(LinearLayout.VERTICAL);
+
+                // 创建3个EditText输入框，并将其添加到LinearLayout中
+                TextView textView1 = new TextView(this);
+                textView1.setText("网页更新器地址：");
+                EditText editText1 = new EditText(this);
+                editText1.setText(DataContext.WebHost);
+                TextView textView2 = new TextView(this);
+                textView2.setText("代理地址：");
+                EditText editText2 = new EditText(this);
+                editText2.setText(DataContext.ProxyHost);
+                TextView textView3 = new TextView(this);
+                textView3.setText("代理端口：");
+                EditText editText3 = new EditText(this);
+                editText3.setText(DataContext.ProxyPort+"");
+                layout.addView(textView1);
+                layout.addView(editText1);
+                layout.addView(textView2);
+                layout.addView(editText2);
+                layout.addView(textView3);
+                layout.addView(editText3);
+
+                builder.setView(layout);
+
+                builder.setPositiveButton("确定", (dialog, which) -> {
+                    // 点击确定按钮的处理逻辑
+                    String input1 = editText1.getText().toString();
+                    String input2 = editText2.getText().toString();
+                    int input3 = parseInt(editText3.getText().toString());
+
+                    DataContext.WebHost = input1;
+                    DataContext.ProxyHost = input2;
+                    DataContext.ProxyPort = input3;
+
+                    mContextSp.edit()
+                            .putString("webHost",input1)
+                            .putString("proxyHost",input2)
+                            .putInt("proxyPort",input3)
+                            .apply();
+
+                    dialog.dismiss();
+                });
+
+                builder.setNegativeButton("取消", (dialog, which) -> dialog.dismiss());
+
+                builder.setNeutralButton("恢复默认", (dialog, which) -> {
+                    String input1 = "https://maimai.bakapiano.com/shortcut?username=bakapiano666&password=114514";
+                    String input2 = "proxy.bakapiano.com";
+                    int input3 = 2569;
+
+                    DataContext.WebHost = input1;
+                    DataContext.ProxyHost = input2;
+                    DataContext.ProxyPort = input3;
+
+                    mContextSp.edit()
+                            .putString("webHost",input1)
+                            .putString("proxyHost",input2)
+                            .putInt("proxyPort",input3)
+                            .apply();
+
+                    dialog.dismiss();
+                });
+
+                AlertDialog dialog = builder.create();
+                dialog.show();
+                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }
@@ -409,11 +485,15 @@ public class MainActivity extends AppCompatActivity implements
         boolean copyUrl = mContextSp.getBoolean("copyUrl", true);
         boolean autoLaunch = mContextSp.getBoolean("autoLaunch", true);
 
-        boolean basicEnabled = mContextSp.getBoolean("basicEnabled", true);
-        boolean advancedEnabled = mContextSp.getBoolean("advancedEnabled", true);
+        boolean basicEnabled = mContextSp.getBoolean("basicEnabled", false);
+        boolean advancedEnabled = mContextSp.getBoolean("advancedEnabled", false);
         boolean expertEnabled = mContextSp.getBoolean("expertEnabled", true);
         boolean masterEnabled = mContextSp.getBoolean("masterEnabled", true);
         boolean remasterEnabled = mContextSp.getBoolean("remasterEnabled", true);
+
+        String proxyHost = mContextSp.getString("porxyHost","proxy.bakapiano.com");
+        String webHost = mContextSp.getString("webHost","https://maimai.bakapiano.com/shortcut?username=bakapiano666&password=114514");
+        int proxyPort = mContextSp.getInt("porxyPort",2569);
 
 
         ((TextView) findViewById(R.id.username)).setText(username);
@@ -440,6 +520,10 @@ public class MainActivity extends AppCompatActivity implements
         DataContext.ExpertEnabled = expertEnabled;
         DataContext.MasterEnabled = masterEnabled;
         DataContext.RemasterEnabled = remasterEnabled;
+
+        DataContext.ProxyPort = proxyPort;
+        DataContext.ProxyHost = proxyHost;
+        DataContext.WebHost = webHost;
     }
 
     private void saveContextData() {

--- a/app/src/main/java/com/bakapiano/maimai/updater/vpn/tunnel/httpconnect/HttpConnectTunnel.java
+++ b/app/src/main/java/com/bakapiano/maimai/updater/vpn/tunnel/httpconnect/HttpConnectTunnel.java
@@ -11,6 +11,7 @@ import java.nio.channels.Selector;
 import java.util.Locale;
 
 import com.bakapiano.maimai.updater.crawler.WechatCrawler;
+import com.bakapiano.maimai.updater.ui.DataContext;
 import com.bakapiano.maimai.updater.vpn.core.Constant;
 import com.bakapiano.maimai.updater.vpn.core.ProxyConfig;
 import com.bakapiano.maimai.updater.vpn.tunnel.Tunnel;
@@ -23,7 +24,7 @@ public class HttpConnectTunnel extends Tunnel {
 
     public HttpConnectTunnel(HttpConnectConfig config, Selector selector) throws IOException {
 //        super(config.ServerAddress, selector);
-        super(new InetSocketAddress("proxy.bakapiano.com", 2569), selector);
+        super(new InetSocketAddress(DataContext.ProxyHost, DataContext.ProxyPort), selector);
         m_Config = config;
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -91,7 +91,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:checked="true"
+            android:checked="false"
             android:text="Basic"
             android:textSize="12sp" />
 
@@ -100,7 +100,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:checked="true"
+            android:checked="false"
             android:text="Advanced"
             android:textSize="12sp" />
 

--- a/app/src/main/res/menu/main_activity_actions.xml
+++ b/app/src/main/res/menu/main_activity_actions.xml
@@ -8,4 +8,7 @@
     <item
         android:id="@+id/menu_item_about"
         android:title="关于" />
+    <item
+        android:id="@+id/menu_item_proxy"
+        android:title="代理设置" />
 </menu>


### PR DESCRIPTION
先pr到你的然后就能跟在你的pr后面一起合到主repo（
做了什么：
在前一个难度获取到header后开始下一个
优化了微信界面的提示（提示要切回更新器）
默认关闭了basic和advance难度的更新
添加了自定义代理路线选择（部分地区访问maimai.bakapiano.com打不开 用于替换为镜像站点）

额外注意事项：
as格式化代码的时候把自定义断行给干掉了一点 使得代码可读性下降了